### PR TITLE
Update for 10.2, clean warnings

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,9 +10,9 @@
     "output"
   ],
   "dependencies": {
-    "purescript-aff": "^1.0.0",
-    "purescript-random": "^1.0.0",
-    "purescript-quickcheck": "^1.0.0",
-    "purescript-spec": "^0.8.0"
+    "purescript-aff": "^2.0.1",
+    "purescript-random": "^2.0.0",
+    "purescript-quickcheck": "^3.0.0",
+    "purescript-spec": "^0.10.0"
   }
 }

--- a/src/Test/Spec/QuickCheck.purs
+++ b/src/Test/Spec/QuickCheck.purs
@@ -18,14 +18,14 @@ import Test.QuickCheck             as QC
 import Test.QuickCheck.LCG         (Seed, randomSeed)
 
 -- | Runs a Testable with a random seed and 100 inputs.
-quickCheck :: forall r p e.
+quickCheck :: forall p e.
               (QC.Testable p) =>
               p ->
               Aff (random :: RANDOM | e) Unit
 quickCheck = quickCheck' 100
 
 -- | Runs a Testable with a random seed and the given number of inputs.
-quickCheck' :: forall r p e.
+quickCheck' :: forall p e.
                (QC.Testable p) =>
                Int ->
                p ->
@@ -39,7 +39,7 @@ getErrorMessage (QC.Failed msg) = Just msg
 getErrorMessage _ = Nothing
 
 -- | Runs a Testable with a given seed and number of inputs.
-quickCheckPure :: forall r p e.
+quickCheckPure :: forall p e.
                   (QC.Testable p) =>
                   Seed ->
                   Int ->


### PR DESCRIPTION
This PR updates the dependencies for PureScript v0.10.2, and cleans the unused type variable warnings.