### PR TITLE
QCRunnerEffects type alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ bower install purescript-spec-quickcheck
 module Test.Main where
 
 import Prelude
-
-import Test.Spec                  (describe, it, pending)
-import Test.Spec.Runner           (run)
+import Control.Monad.Eff (Eff)
+import Test.QuickCheck ((===), (/==))
+import Test.Spec (describe, it)
+import Test.Spec.QuickCheck (QCRunnerEffects, quickCheck)
 import Test.Spec.Reporter.Console (consoleReporter)
-import Test.QuickCheck            ((===), (/==))
+import Test.Spec.Runner (run)
 
-import Test.Spec.QuickCheck       (quickCheck)
-
+main :: Eff (QCRunnerEffects ()) Unit
 main = run [consoleReporter] do
   describe "Math" do
     it "works" $

--- a/src/Test/Spec/QuickCheck.purs
+++ b/src/Test/Spec/QuickCheck.purs
@@ -1,4 +1,5 @@
 module Test.Spec.QuickCheck (
+  QCRunnerEffects,
   quickCheck,
   quickCheck',
   quickCheckPure
@@ -16,6 +17,9 @@ import Data.List                   (mapMaybe, length)
 import Data.Maybe                  (Maybe(..))
 import Test.QuickCheck             as QC
 import Test.QuickCheck.LCG         (Seed, randomSeed)
+import Test.Spec.Runner            (RunnerEffects)
+
+type QCRunnerEffects e = RunnerEffects (random :: RANDOM | e)
 
 -- | Runs a Testable with a random seed and 100 inputs.
 quickCheck :: forall p e.

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -2,14 +2,13 @@ module Test.Main where
 
 import Prelude
 import Control.Monad.Eff (Eff)
-import Control.Monad.Eff.Random (RANDOM)
 import Test.QuickCheck ((===), (/==))
 import Test.Spec (describe, it)
-import Test.Spec.QuickCheck (quickCheck)
+import Test.Spec.QuickCheck (QCRunnerEffects, quickCheck)
 import Test.Spec.Reporter.Console (consoleReporter)
-import Test.Spec.Runner (RunnerEffects, run)
+import Test.Spec.Runner (run)
 
-main :: Eff (RunnerEffects (random :: RANDOM)) Unit
+main :: Eff (QCRunnerEffects ()) Unit
 main = run [consoleReporter] do
   describe "Math" do
     it "works" $


### PR DESCRIPTION
A handy convenience for specs written with this lib.
Used in the tests here and in the corresponding `README` sample code.