### PR TITLE
Migrate to PureScript 0.14.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .psci
 .psci_modules/
+/.psc-ide-port
 bower_components/
 node_modules/
 output/

--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
     "purescript-prelude": "^5.0.0",
     "purescript-aff": "^6.0.0",
     "purescript-random": "^5.0.0",
-    "purescript-quickcheck": "master",
+    "purescript-quickcheck": "^7.0.0",
     "purescript-spec": "^5.0.0"
   },
   "license": "MIT",

--- a/bower.json
+++ b/bower.json
@@ -9,15 +9,15 @@
     "output"
   ],
   "dependencies": {
-    "purescript-prelude": "^4.0.0",
-    "purescript-aff": "^5.0.0",
-    "purescript-random": "^4.0.0",
-    "purescript-quickcheck": "^5.0.0",
-    "purescript-spec": "^3.1.0"
+    "purescript-prelude": "^5.0.0",
+    "purescript-aff": "^6.0.0",
+    "purescript-random": "^5.0.0",
+    "purescript-quickcheck": "master",
+    "purescript-spec": "^5.0.0"
   },
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git://github.com/owickstrom/purescript-spec-quickcheck.git"
+    "url": "https://github.com/owickstrom/purescript-spec-quickcheck.git"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,6 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/owickstrom/purescript-spec-quickcheck.git"
+    "url": "https://github.com/purescript-spec/purescript-spec-quickcheck.git"
   }
 }

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,15 +1,17 @@
 module Test.Main where
 
 import Prelude
+
 import Effect (Effect)
+import Effect.Aff (launchAff_)
 import Test.QuickCheck ((===), (/==))
 import Test.Spec (describe, it)
 import Test.Spec.QuickCheck (quickCheck)
 import Test.Spec.Reporter.Console (consoleReporter)
-import Test.Spec.Runner (run)
+import Test.Spec.Runner (runSpec)
 
 main :: Effect Unit
-main = run [consoleReporter] do
+main = launchAff_ $ runSpec [consoleReporter] do
   describe "Math" do
     it "works" $
       quickCheck \n -> (n * 2 / 2) === n


### PR DESCRIPTION
This PR makes updates dependency versions to build with the shiny new PureScript 0.14.0 compiler.